### PR TITLE
bg(getSpecificLoan): User can Only retrieve their own loan

### DIFF
--- a/server/controller/loanController.js
+++ b/server/controller/loanController.js
@@ -97,9 +97,14 @@ class Loans {
    */
   static async getOne(req, res, next) {
     const id = parseInt(req.params.id, 10);
+    const userId = parseInt(res.locals.userId, 10);
     const loan = await LoanModel.findById(id);
     if (!loan) {
       return errorRes(next, 404, 'Loan with this id was not found');
+    }
+    const loanUserId = await LoanModel.getUserIdFromLoanId(id);
+    if (!res.locals.isAdmin) {
+      if (loanUserId !== userId) return errorRes(next, 401, 'You cannot view another users Loan');
     }
     return successRes(res, 200, loan);
   }

--- a/server/middleware/verifyToken.js
+++ b/server/middleware/verifyToken.js
@@ -18,9 +18,10 @@ class Verify {
       token = token.slice(7, token.length);
     }
     try {
-      const { userId, email } = jwt.verify(token, process.env.SECRETkey);
+      const { userId, email, isAdmin } = jwt.verify(token, process.env.SECRETkey);
       res.locals.userId = userId;
       res.locals.email = email;
+      res.locals.isAdmin = isAdmin;
       next();
     } catch (error) {
       return errorRes(next, 401, 'Invalid Token Provided');
@@ -44,6 +45,7 @@ class Verify {
       if (!isAdmin) return errorRes(next, 403, 'You do not have authorization to access this route');
       res.locals.userId = userId;
       res.locals.email = email;
+      res.locals.isAdmin = isAdmin;
       next();
     } catch (error) {
       return errorRes(next, 401, 'Invalid Token Provided');

--- a/server/models/loanModel.js
+++ b/server/models/loanModel.js
@@ -144,6 +144,16 @@ class LoanModel {
     const { rows } = await db.query(text, [id]);
     return rows[0].status;
   }
+
+  /**
+   * Retrieves the Users ID for the provided Loan ID
+   * @param {number} id - Loan ID
+   */
+  static async getUserIdFromLoanId(id) {
+    const text = 'SELECT users.id FROM users INNER JOIN loans ON (users.email = loans.email) WHERE loans.id = $1';
+    const { rows } = await db.query(text, [id]);
+    return rows[0].id;
+  }
 }
 
 export default LoanModel;

--- a/server/test/loans.test.js
+++ b/server/test/loans.test.js
@@ -289,9 +289,17 @@ describe('Get /loans/:id', () => {
     res.body.should.have.property('error');
     res.body.should.have.property('status').eql(404);
   });
-  it('should LIST a SINGLE Loan', async () => {
+  it('should NOT LIST a single Loan if loan does not belong to user', async () => {
     const id = 1;
     const res = await request.get(`/api/v1/loans/${id}`).set('authorization', `${userToken}`);
+    res.should.have.status(401);
+    res.body.should.be.a('object');
+    res.body.should.have.property('error');
+    res.body.should.have.property('status').eql(401);
+  });
+  it('should LIST a SINGLE Loan', async () => {
+    const id = 1;
+    const res = await request.get(`/api/v1/loans/${id}`).set('authorization', `${adminToken}`);
     res.should.have.status(200);
     res.body.data.should.be.a('object');
     res.body.data.should.have.property('id');


### PR DESCRIPTION
#### What does this PR do?
User Can Only retrieve their own loan 

#### Description of Task to be completed
A user should be able to only retrieve their own loan applications. Any attempt by a user to retrieve another users loan should throw an error.

#### How should this be manually tested?
1. Clone this branch.
2. Run `npm install` to install the dependencies.
3. Run `npm test` to run the tests.

#### What are the relevant pivotal tracker stories?
[#166212913](https://pivotaltracker.com/story/show/166212913)

#### Screenshots (if appropriate)
![Screenshot from 2019-05-23 17-21-14](https://user-images.githubusercontent.com/39800005/58269325-35e48c80-7d7f-11e9-98b1-b2116ca799a1.png)
