### PR TITLE
bg(repayments): User can only get their repayments history

### DIFF
--- a/server/controller/loanController.js
+++ b/server/controller/loanController.js
@@ -189,6 +189,11 @@ class Loans {
     if (!loanRepaymentsArray.length) {
       return errorRes(next, 404, `Repayments for Loan with ID: ${loanId} not found`);
     }
+    const userId = parseInt(res.locals.userId, 10);
+    const loanUserId = await LoanModel.getUserIdFromLoanId(loanId);
+    if (!res.locals.isAdmin) {
+      if (loanUserId !== userId) return errorRes(next, 401, 'You cannot view another users repayment history');
+    }
     return successRes(res, 200, loanRepaymentsArray);
   }
 }

--- a/server/test/repayments.test.js
+++ b/server/test/repayments.test.js
@@ -117,9 +117,16 @@ describe('GET /loans/:id/repayments', () => {
     res.body.should.have.property('error');
     res.body.should.have.property('status').eql(404);
   });
-  it('Should return list of repayments', async () => {
+  it('Should NOT return list of repayments if request is not sent by owner of loan', async () => {
     const id = 6;
     const res = await request.get(`/api/v1/loans/${id}/repayments`).set('authorization', `${userToken}`);
+    res.should.have.status(401);
+    res.body.should.have.property('error');
+    res.body.should.have.property('status').eql(401);
+  });
+  it('Should return list of repayments', async () => {
+    const id = 6;
+    const res = await request.get(`/api/v1/loans/${id}/repayments`).set('authorization', `${adminToken}`);
     res.should.have.status(200);
     res.body.should.have.property('data');
     res.body.data.should.be.a('array');


### PR DESCRIPTION
#### What does this PR do?
User can only retrieve his/her repayments history

#### Description of Task to be completed
- When a user sends a request to get loan repayments of another user, it should return an error

#### How should this be manually tested?
1. Clone this branch.
2. Run `npm install` to install the dependencies.
3. Run `npm test` to run the tests.

#### What are the relevant pivotal tracker stories?
[#166223421](https://pivotaltracker.com/story/show/166223421)

#### Screenshots (if appropriate)
![Screenshot from 2019-05-23 22-24-32](https://user-images.githubusercontent.com/39800005/58287838-f2534800-7da9-11e9-9945-1b3355403ecb.png)
